### PR TITLE
Remove archival notice from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-### **Archived - Repo moved to https://github.com/bitburner-official/bitburner-vscode**
-
-----
-
 # Bitburner Connector for VSCode
 
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)


### PR DESCRIPTION
Since this is now on the bitburner-official organization, it makes sense to remove this from the README.