### PR TITLE
chore: update outdated repository references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 - Fork this repository
 - Make your changes
-- Create a [Pull Request](https://github.com/hexnaught/vscode-bitburner-connector/compare) from your fork, to the `hexnaught/vscode-bitburner-connector` repository with `develop` as the base branch.
+- Create a [Pull Request](https://github.com/bitburner-official/bitburner-vscode/compare) from your fork, to the `bitburner-official/bitburner-vscode` repository with `develop` as the base branch.
 - The PR will be reviewed and either merged or commented on.
     - If the PR has comments, it will remain open until all comments are resolved.
     - The PR will be squashed and merged in to `develop`
@@ -15,7 +15,7 @@ _If you don't/haven't followed these guidelines, don't worry! I will update the 
 
 We are using `semantic-release` to help automate and version our releases, this relies on commit messages to be in a specific format - We are using the 'Angular' preset, see [the Angular Commit Message Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commit-message-format) for examples.
 
-We can support custom keywords, these can be seen under the `@semantic-release/commit-analyzer` `releaseRules` within [`.releaserc`](https://github.com/hexnaught/vscode-bitburner-connector/blob/master/.releaserc).
+We can support custom keywords, these can be seen under the `@semantic-release/commit-analyzer` `releaseRules` within [`.releaserc`](https://github.com/bitburner-official/bitburner-vscode/blob/master/.releaserc).
 
 Current Custom Release Rules:
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ When the game is started for the first time, it generates an 'Auth Token' that c
 
 You can copy the token from the Bitburner application 'API Server' context menu:
 
-![Image showing API Server context menu in the bitburner game client](https://raw.githubusercontent.com/hexnaught/vscode-bitburner-connector/assets/images/bit-burner-menu-auth-token.png)
+![Image showing API Server context menu in the bitburner game client](https://raw.githubusercontent.com/bitburner-official/bitburner-vscode/assets/images/bit-burner-menu-auth-token.png)
 
 #### Adding the token to the extension:
 

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/hexnaught/vscode-bitburner-connector"
+    "url": "https://github.com/bitburner-official/bitburner-vscode"
   },
   "bugs": {
-    "url": "https://github.com/hexnaught/vscode-bitburner-connector/issues"
+    "url": "https://github.com/bitburner-official/bitburner-vscode/issues"
   },
   "contributors": [
     "Hexnaught <danj.parkes@gmail.com>"


### PR DESCRIPTION
Updates the references in the repository to point to `bitburner-official/bitburner-vscode` instead of the now archived `hexnaught/vscode-bitburner-connector`.

closes #23 