### PR TITLE
Translate relative imports ('./', '../') to BB file system requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,11 @@
             "default": "./",
             "description": "The root directory of the scripts you want to push to the game. (Use with the File Watcher)"
           },
+          "bitburner.replaceJsImportPaths": {
+            "type": "boolean",
+            "default": false,
+            "description": "Convert javascript import paths when pushing scripts so './' and '../' can be used"
+          },
           "bitburner.fileWatcher.enable": {
             "type": "boolean",
             "default": false,

--- a/src/extension.js
+++ b/src/extension.js
@@ -281,7 +281,7 @@ const replaceJsImportPathsForBB = (fileName, jsContent) => {
   let hierarchy = fileName.split('/');
   if (hierarchy.length > 0) hierarchy.pop();
 
-  jsContent = jsContent.replace(/(import(?:[^]*?)(['"]))([^]*?)(\2(?:\s*);)/g, function (match, start, quote, path, end) {
+  jsContent = jsContent.replace(/(import(?:[^]*?)(['"]))([^]*?)(\2(?:\s*))/g, function (match, start, quote, path, end) {
     return start + refactorJsImportPathForBB(path, hierarchy) + end;
   });
 


### PR DESCRIPTION
When you write relative imports in a script that is not in a root directory, like (assuming that bitburner.scriptRoot is set to "./out/", but it is the same as if it was not set):

```
out/
|    somefolder/
|    |    innerfolder/
|    |    | innerscript.js
|    | somescript.js
|    | neighbourscript.js
| rootscript.js
```

in /out/somefolder/somescript.js:
```
import { foo } from './innerfolder/innerscript.js';
import { bar } from './neighbourscript.js';
import { bit } from 'neighbourscript.js';
import { more } from '../rootscript.js';
import { examples } from './../rootscript.js';
```
This gives a working Intellisense in VS Code , but any of the given lines will result in failure while running the script inside BitBurner. Third example (bit) will work though, but only from files that are in root directory.

To make imports work in BB you have to change them to:
```
import { foo } from '/somefolder/innerfolder/innerscript.js';
import { bar } from '/somefolder/neighbourscript.js';
import { bit } from '/somefolder/neighbourscript.js';
import { more } from '/rootscript.js';
import { examples } from '/rootscript.js';
```

This makes the script working in BitBurner, but breaks Intellisense in VS Code.

The change does refactoring at script push time, so you can keep relative paths in VS Code.

I think it should be enabled by default, but I added and disabled it in the package config `bitburner.replaceJsImportPaths` if it needs time to test.